### PR TITLE
Remove obvious spam links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 
 In recent years the `revctrl.org` wiki has fallen victim to spam,
 making it hard to find the valuable content that still resides there.
-This is my first-pass attempt at extracting what remains of value.
+This is an attempt at extracting what remains of value.
 
 Produced partly by hand, partly using the `pull` script in this
-directory.
+directory, then removed obvious spam links from the files in
+`output-raw`.
 
 The page contents were downloaded on the 12th July 2012.
 
-I have not yet been through the pages removing the spam links. Once
-that's done, perhaps I'll make a PDF or a TiddlyWiki of the content or
-something.
+Perhaps I'll make a PDF or a TiddlyWiki of the content or something.
 
  -- Tony Garnock-Jones <tonygarnockjones@gmail.com>

--- a/output-raw/AccidentalCleanMerge
+++ b/output-raw/AccidentalCleanMerge
@@ -39,4 +39,3 @@ DarcsMerge sees this as a conflict.
 ----
 
 CategoryMergeExample
-[[http://www.barcelonasuitesabq.com/|albuquerque airport hotels]]

--- a/output-raw/CategoryMergeAlgorithm
+++ b/output-raw/CategoryMergeAlgorithm
@@ -11,13 +11,3 @@ To add a page to this category, add a link to this page on the last line of the 
 
 ----
 CategoryCategory
-
-
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://crusherzone.com/2012/04/Jaw Crusher,Jaw Cruhser machine Jaw Crusher For Sale/|Jaw Crusher vs Jaw Tickets]]
-[[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/pacquiao-vs-marquez-official-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://pacquiaovsmarquez3live.com/2011/08/bernard-hopkins-vs-chad-dawson-official-tickets-for-sale/|Hopkins vs Dawson Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/nonito-donaire-vs-omar-narvaez-official-tickets-for-sale/|Donaire vs Narvaez Tickets]]
-[[http://pacquiaovsmarquez3live.com/|Pacquiao vs Marquez]]
-[[http://donairevsnarvaezlive.blogspot.com/|Donaire vs Narvaez]]

--- a/output-raw/CategoryMergeExample
+++ b/output-raw/CategoryMergeExample
@@ -11,10 +11,3 @@ To add a page to this category, add a link to this page on the last line of the 
 
 ----
 CategoryCategory
-
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]

--- a/output-raw/ConceptTable
+++ b/output-raw/ConceptTable
@@ -1,4 +1,4 @@
-The revctrl Rosetta stone.  Table of concepts available to revision control [[http://www.grabcasinobonus.com/casino-bonuses/|Mobile Casino No Deposit Bonus]] systems and (if available) the corresponding commands.
+The revctrl Rosetta stone.  Table of concepts available to revision control systems and (if available) the corresponding commands.
 
 Please add your own.  Note: I'm using GUI mode to edit this table
 ||'''concept''' ||'''bzr''' ||'''darcs''' ||'''hg''' ||'''svn''' ||
@@ -7,7 +7,7 @@ Please add your own.  Note: I'm using GUI mode to edit this table
 ||commit locally ||commit --local ||record ||commit ||''    na'' ||
 ||commit to repo ||commit ||''see push/send'' ||''see push'' ||commit ||
 ||create new repository ||init ||init ||init ||import ||
-||diff local ||diff ||whatsnew ||diff || diff || [[http://www.casinoluckywin.com/en/mobile/|mobile casino]]
+||diff local ||diff ||whatsnew ||diff || diff ||
 ||diff repos or versions ||diff ||diff ||incoming/outgoing/diff -r ||diff ||
 ||<style="vertical-align: top;">file copy ||<style="vertical-align: top;">na||<style="vertical-align: top;">''na'' ||<style="vertical-align: top;">copy ||<style="vertical-align: top;">copy ||
 ||<style="vertical-align: top;">file move ||<style="vertical-align: top;">mv||<style="vertical-align: top;">mv ||<style="vertical-align: top;">move ||<style="vertical-align: top;">move ||
@@ -25,22 +25,12 @@ Please add your own.  Note: I'm using GUI mode to edit this table
 
 == Concepts ==
  * manifest - to see what files are under version control
- * tag changes/revisions - to mark a certain revision, or set of changes as special in some way, like "PRERELEASE", or "2.0.3" [[http://www.bouncewow.com/|Bounce House Rental Mesa AZ]]
+ * tag changes/revisions - to mark a certain revision, or set of changes as special in some way, like "PRERELEASE", or "2.0.3"
  * what's the difference between pull and "update from repo"?
 == Notes ==
  * ''na'' - this concept is not available in this revctrl system
- * ''see...'' - this concept is not available, but the revctrl system uses a different concept of [[http://www.casinomagic.co.uk/slotgames/|Online Slots]] in its place
+ * ''see...'' - this concept is not available, but the revctrl system uses a different concept in its place
 
 == See also ==
 
  * Rosetta Stone from a [[http://wiki.darcs.net/RosettaStone|Darcs perspective]]
-[[http://www.yourminskapartment.com/|accommodation in Minsk]]
-[[http://donairevsnarvaezlive.blogspot.com/|Donaire vs Narvaez]]
-[http://www.crusherzone.com]
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[http://www.crusherzone.com]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]

--- a/output-raw/CrissCrossMerge
+++ b/output-raw/CrissCrossMerge
@@ -11,35 +11,20 @@ A criss-cross merge is an ancestry graph in which minimal common ancestors are n
 }}}
 
 ---- /!\ '''Edit conflict - other version:''' ----
-The story one [[http://www.easyessayhelp.com| essay writing]] can tell here is that Bob and Claire made [[http://www.beerocity.com beer glasses] some change independently [[http://www.easyessayhelp.com/write-my-research-paper.php| write my research paper]], then each merged the changes together.  They conflicted, and Bob (of course) decided his change was better, while Claire (typically) picked her version.  Now, we need to merge again.  This should be a conflict. 
-Note that this [[http://www.gardenspotvillage.org|Best Retirement Communities]] can happen equally well with a textual merger -- they have [[http://www.webpages.ca|seo]] each edited the same place in the file, and when resolving [[http://www.cleanfresnocarpets.com|clovis carpet cleaning]] the conflict  they each choose to make the resulting text identical to their original version (i.e., they don't munge the two edits together somehow, they just pick one to win).
+The story one can tell here is that Bob and Claire made some change independently, then each merged the changes together.  They conflicted, and Bob (of course) decided his change was better, while Claire (typically) picked her version.  Now, we need to merge again.  This should be a conflict. 
+Note that this can happen equally well with a textual merger -- they have each edited the same place in the file, and when resolving the conflict  they each choose to make the resulting text identical to their original version (i.e., they don't munge the two edits together somehow, they just pick one to win).
 
-This is [[http://www.valleypistachio.com/| buy pistachios]] one of the key examples [[http://www.easyessayhelp.com/write-my-essay.php| help me write my essay]] that has driven development of merge algorithms; there is currently no textual merge algorithm that fully handles this case (probably - see below).[[http://www.swimtownpools.com/Pool-Solutions-3-Stabilized-Chlorine-Tablets-p/p27050de.htm| 3 inch chlorine tablets]]
-[[http://www.swimtownpools.com/pool-liners-s/8.htm| above ground pool liner]]
-[[http://www.silverliningherbs.com| dog health supplements]]
-[[http://www.globalliftcorp.com| pool lifts]]
-[[http://www.cavite-housing.com/category/lancaster-estates/|cavite homes]]
-[[http://www.datarecoverygroup.com| data recovery]]
-[[http://www.valleybrokers.com| corvallis homes for sale]]
-[[http://www.swimtownpools.com/BIO-LAB-CHLORINATOR-MA18B-with-flow-meter-p/25118000.htm| biolab pool chlorinator]]
-[[http://www.swimtownpools.com/swimming-pool-paint-s/335.htm| swimming pool paint]]
-[[http://www.swimtownpools.com/all-above-ground-pools-s/1.htm| above ground pools]]
-[[http://www.swimtownpools.com| pool supplies]]
-[[http://www.capitalsteel.net| Steel bar]]
-[[http://www.swimtownpools.com/gas-pool-heaters-s/190.htm| Gas pool heater]]
-[[http://www.swimtownpools.com/pool-chemical-feeders-s/170.htm| pool chemical feeder]]
-[[http://www.swimtownpools.com/swimming-pool-lights-s/228.htm| swimming pool lights]]
-[[http://www.ssdcs.com| Michigan disability attorney]]
+This is one of the key examples that has driven development of merge algorithms; there is currently no textual merge algorithm that fully handles this case (probably - see below).
 
 ---- /!\ '''Edit conflict - your version:''' ----
-The story one can tell here is that Bob and Claire made some change independently, then each merged the changes together.  They conflicted, and Bob (of course) decided his change was better, while Claire (typically) picked her version.  Now, we need to merge again [[http://en.wikipedia.org/wiki/Susan_Lim|Dr Susan Lim]].  This should be a conflict.
+The story one can tell here is that Bob and Claire made some change independently, then each merged the changes together.  They conflicted, and Bob (of course) decided his change was better, while Claire (typically) picked her version.  Now, we need to merge again.  This should be a conflict.
 
 
 Note that this can happen equally well with a textual merger -- they have each edited the same place in the file, and when resolving the conflict  they each choose to make the resulting text identical to their original version (i.e., they don't munge the two edits together somehow, they just pick one to win).
 
 
 
-This is one of the key examples that has driven development of merge algorithms; there is currently no textual merge algorithm that fully handles this case[[http://www.weldingtrainingcenter.com/welding-schools|welding school]] (probably - see below).
+This is one of the key examples that has driven development of merge algorithms; there is currently no textual merge algorithm that fully handles this case (probably - see below).
 
 
 ---- /!\ '''End of edit conflict''' ----
@@ -52,43 +37,43 @@ ThreeWayMerge has obvious problems here -- there are two "least" (or more proper
 ---- /!\ '''Edit conflict - your version:''' ----
 
 ---- /!\ '''End of edit conflict''' ----
-Furthermore, using ''either'' of them as a base for the merge will give an incorrectly clean merge -- if b1 as used as a base, it will appear that b2 is [[http://www.easyessayhelp.com/research-paper.php|buy research paper]] unchanged while c2 has changed, therefore c2 will win.  If c1 is used as a base, the opposite occurs.
+Furthermore, using ''either'' of them as a base for the merge will give an incorrectly clean merge -- if b1 as used as a base, it will appear that b2 is unchanged while c2 has changed, therefore c2 will win.  If c1 is used as a base, the opposite occurs.
 
-One possible solution is to use 'a' as the common ancestor for the merge; this is the approach taken by ["Monotone"], when it uses the ["LCA+DOM"] rather than ["LCA"] as a merge base.  However, this approach has its own problems  [[http://www.espycamera.com|Spy Equipment]]
+One possible solution is to use 'a' as the common ancestor for the merge; this is the approach taken by ["Monotone"], when it uses the ["LCA+DOM"] rather than ["LCA"] as a merge base.  However, this approach has its own problems.
 
 ---- /!\ '''Edit conflict - other version:''' ----
 
 == Recursive three-way merge ==
-Another possible solution is to first merge 'b1' and 'c1' to a temporary node (basically, imagine that the 'X' in the diagram is actually a revision, not just edges crossing) and then use that as a base for merging 'b2' and 'c2'. The interesting part is when merging 'b1' and 'c1' results in conflicts - the trick is that in that case, 'X' is included ''with the conflicts recorded inside'' (e.g. using the classical conflict markers). Since both 'b2' and 'c2' had to resolve the same conflict, in the case they resolved it the same way they both remove the conflicts from 'X' in the same way and a clean [[http://www.thebestpokersite.com/shop/Tables-amp-Chairs/Premium-Poker-Tables-c19/|bbo poker tables]] merge results; if they resolved it in different ways, the conflicts from 'X' get propagated to the final merge result. If a merge would result in more than two bases ('b1', 'c1, 'd1'), they are merged consecutively - first 'b1' with 'c1' and then the result with 'd1' .
+Another possible solution is to first merge 'b1' and 'c1' to a temporary node (basically, imagine that the 'X' in the diagram is actually a revision, not just edges crossing) and then use that as a base for merging 'b2' and 'c2'. The interesting part is when merging 'b1' and 'c1' results in conflicts - the trick is that in that case, 'X' is included ''with the conflicts recorded inside'' (e.g. using the classical conflict markers). Since both 'b2' and 'c2' had to resolve the same conflict, in the case they resolved it the same way they both remove the conflicts from 'X' in the same way and a clean merge results; if they resolved it in different ways, the conflicts from 'X' get propagated to the final merge result. If a merge would result in more than two bases ('b1', 'c1, 'd1'), they are merged consecutively - first 'b1' with 'c1' and then the result with 'd1' .
 
-This is what ["Git"]'s "recursive merge" strategy doe[s.
+This is what ["Git"]'s "recursive merge" strategy does.
 
 
 Recursive three-way merge ''usually'' provides the right answer, however there are some edge cases. For example, conflict markers can be matched incorrectly, because they aren't given any special semantic meaning for the merge algorithm, and are simply treated as lines. In particular, there are (somewhat complicated) cases where the conflict markers of two unrelated conflicts get matched against each other, even though the content sections of them are totally unrelated.
 
-Also, recursive merge can do some of the same invalid merges as SimpleWeaveMerge does, which are described below, although exactly what it does under those circumstances is highly dependant on the details of the 3 way merge algorithm, but it isn't clear that tweaking the 3-way merge algorithm to be more conservative about showing conflicts will make such problems go away. Basically, including the conflict is creating a weave, and that introduces the problems which weaves have. [[http://favoritefilipinofoods.blogspot.com/|Filipino Recipes]]
-]
-Finally, recursive three-way merge has all the inherent problems of ImplicitUndo. In particular, merging together multiple things which merge cleanly will sometimes give different answers depending on the order in which the merges happen. In fact, it's possible in a never-ending criss-cross case for a value to flip-flop until the end of time without ever getting a single [[http://mayweatherversusortiz.com/2011/09/pacquiao-vs-marquez-official-tickets-for-sale/|Pacquiao vs Marquez Tickets]] unclean merge. This is a very fundamental problem, and fixing it requires first deciding what one wants to have happen in such cases, because what is appropriate behavior is unclear.
+Also, recursive merge can do some of the same invalid merges as SimpleWeaveMerge does, which are described below, although exactly what it does under those circumstances is highly dependant on the details of the 3 way merge algorithm, but it isn't clear that tweaking the 3-way merge algorithm to be more conservative about showing conflicts will make such problems go away. Basically, including the conflict is creating a weave, and that introduces the problems which weaves have.
+
+Finally, recursive three-way merge has all the inherent problems of ImplicitUndo. In particular, merging together multiple things which merge cleanly will sometimes give different answers depending on the order in which the merges happen. In fact, it's possible in a never-ending criss-cross case for a value to flip-flop until the end of time without ever getting a single unclean merge. This is a very fundamental problem, and fixing it requires first deciding what one wants to have happen in such cases, because what is appropriate behavior is unclear.
 
 ---- /!\ '''Edit conflict - your version:''' ----
 
 == Recursive three-way merge ==
-Another possible solution is to first merge 'b1' and 'c1' to a temporary node (basically, imagine that the 'X' in the diagram is actually a revision, not just edges crossing) and then use that as a base for merging 'b2' and 'c2'. The interesting part is when merging 'b1' and 'c1' results in conflicts - the trick is that in that case, 'X' is included ''with the conflicts recorded inside'' (e.g. using the classical conflict markers). Since both 'b2' and 'c2' had to resolve the same conflict, in the case they resolved it the same way they both remove the conflicts from 'X' in the same way and a clean merge results; if they resolved it in different ways, the conflicts from 'X' get propagated to the final [[http://www.pacquiaovsmarquezfight.com|pacquiao vs marquez live streaming]] merge result. If a merge would result in more than two bases ('b1', 'c1, 'd1'), they are merged consecutively - first 'b1' with 'c1' and then the result with 'd1' .
+Another possible solution is to first merge 'b1' and 'c1' to a temporary node (basically, imagine that the 'X' in the diagram is actually a revision, not just edges crossing) and then use that as a base for merging 'b2' and 'c2'. The interesting part is when merging 'b1' and 'c1' results in conflicts - the trick is that in that case, 'X' is included ''with the conflicts recorded inside'' (e.g. using the classical conflict markers). Since both 'b2' and 'c2' had to resolve the same conflict, in the case they resolved it the same way they both remove the conflicts from 'X' in the same way and a clean merge results; if they resolved it in different ways, the conflicts from 'X' get propagated to the final merge result. If a merge would result in more than two bases ('b1', 'c1, 'd1'), they are merged consecutively - first 'b1' with 'c1' and then the result with 'd1' .
 
-This is what ["Git"]'s "recursive merge" strategy doe[s.
+This is what ["Git"]'s "recursive merge" strategy does.
 
 
 Recursive three-way merge ''usually'' provides the right answer, however there are some edge cases. For example, conflict markers can be matched incorrectly, because they aren't given any special semantic meaning for the merge algorithm, and are simply treated as lines. In particular, there are (somewhat complicated) cases where the conflict markers of two unrelated conflicts get matched against each other, even though the content sections of them are totally unrelated.
 
-Also, recursive merge can do some of the same invalid merges as SimpleWeaveMerge does, which are described below, although exactly what it does under those circumstances is highly dependant on the details of the 3 way merge algorithm, but it isn't clear that tweaking the 3-way merge algorithm to be more conservative about showing conflicts will make such problems go away. Basically, including the conflict is creating a weave, and that introduces the problems which weaves have [[http://www.naturemill.com/|Compost Bin]].
-]
-Finally, recursive three-way merge has all the inherent problems of ImplicitUndo. In particular, merging together multiple things which merge cleanly will sometimes give different answers depending on the order in which the merges happen. In fact, it's possible in a never-ending criss-cross case for a value to flip-flop until the end of time without ever getting a single unclean merge. This is a very fundamental problem, and fixing it requires [[http://www.mayweathervsortizfight.com/mayweather-vs-ortiz-tickets|mayweather vs ortiz tickets]] first deciding what one wants to have happen in such cases, because what is appropriate behavior is unclear.
+Also, recursive merge can do some of the same invalid merges as SimpleWeaveMerge does, which are described below, although exactly what it does under those circumstances is highly dependant on the details of the 3 way merge algorithm, but it isn't clear that tweaking the 3-way merge algorithm to be more conservative about showing conflicts will make such problems go away. Basically, including the conflict is creating a weave, and that introduces the problems which weaves have.
+
+Finally, recursive three-way merge has all the inherent problems of ImplicitUndo. In particular, merging together multiple things which merge cleanly will sometimes give different answers depending on the order in which the merges happen. In fact, it's possible in a never-ending criss-cross case for a value to flip-flop until the end of time without ever getting a single unclean merge. This is a very fundamental problem, and fixing it requires first deciding what one wants to have happen in such cases, because what is appropriate behavior is unclear.
 
 ---- /!\ '''End of edit conflict''' ----
 = Scalar codeville merge =
 Traditional CodevilleMerge on scalar values gives an AmbiguousCleanMerge here -- the last-changed revision for b2 is b1, which is an ancestor of c2, and thus c2 should win cleanly; similarly, the last-changed revision for c2 is c1, which is an ancestor of b2, and thus b2 should win cleanly.
 
-This somewhat anomalous case is normally presented to the user as a conflict (what else can one do?), which is the right result.  But [[http://thehemorrhoidguide.com/What-is-a-Hemorrhoid.php|What is a hemorrhoid]] there [[http://donairevsnarvaezlive.blogspot.com/|Donaire vs Narvaez]] is a more subtle problem:
+This somewhat anomalous case is normally presented to the user as a conflict (what else can one do?), which is the right result.  But there is a more subtle problem:
 
 {{{
    a
@@ -103,10 +88,10 @@ This somewhat anomalous case is normally presented to the user as a conflict (wh
 }}}
 
 ---- /!\ '''Edit conflict - other version:''' ----
-Suppose someone else commits another version under c2, in which they didn't touch this scalar at all -- they are blissfully ignorant of Bob and Claire's shenanigans.  Now, this should merge cleanly -- someone has resolved the b2/c2 conflict, someone else has made no changes at all, all should be fine. But it's not; it's another [[http://mayweatherversusortiz.com/|Hopkins vs Dawson]] [[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]] ambiguous clean merge, because the last-changed revisions for b3 and c3 are still b1 and c1, respectively.  In fact, this can continue arbitrarily long:
+Suppose someone else commits another version under c2, in which they didn't touch this scalar at all -- they are blissfully ignorant of Bob and Claire's shenanigans.  Now, this should merge cleanly -- someone has resolved the b2/c2 conflict, someone else has made no changes at all, all should be fine. But it's not; it's another ambiguous clean merge, because the last-changed revisions for b3 and c3 are still b1 and c1, respectively.  In fact, this can continue arbitrarily long:
 
 ---- /!\ '''Edit conflict - your version:''' ----
-Suppose someone else commits another version under c2, in which they didn't touch this scalar at all -- they are blissfully ignorant of Bob and Claire's shenanigans.  Now, this should merge cleanly -- someone has resolved the b2/c2 conflict, someone else has made no changes at all, all should be fine. But it's not; it's another ambiguous clean merge, because the last-changed revisions for [[http://pacquiaoversusmarquez-lll.blogspot.com/|Pacquiao vs Marquez]] b3 and c3 are still b1 and c1, respectively.  In fact, this can continue arbitrarily long:
+Suppose someone else commits another version under c2, in which they didn't touch this scalar at all -- they are blissfully ignorant of Bob and Claire's shenanigans.  Now, this should merge cleanly -- someone has resolved the b2/c2 conflict, someone else has made no changes at all, all should be fine. But it's not; it's another ambiguous clean merge, because the last-changed revisions for b3 and c3 are still b1 and c1, respectively.  In fact, this can continue arbitrarily long:
 
 ---- /!\ '''End of edit conflict''' ----
 
@@ -123,7 +108,7 @@ Suppose someone else commits another version under c2, in which they didn't touc
     \ / \
      b4  c4
 }}}
-This is yet another conflict.  These conflicts continue so long as new versions are committed that do not have the ambiguous-clean resolution as an ancestor [[http://nofaxpayday-loans.com/|no fax payday loans]].
+This is yet another conflict.  These conflicts continue so long as new versions are committed that do not have the ambiguous-clean resolution as an ancestor.
 
 (Of course, if at any point someone resolves one of these repeated conflicts in favor of c, then things get even more complicated.
 
@@ -237,22 +222,7 @@ m(b,c) m(b,c)
     b2  c2
 }}}
 
-Where m(b,c) is a "merger" patch for b1 and c1 for [[http://www.southamptonlocksmiths24hrs.co.uk|Southampton Locksmiths]] [[http://www.caldwells.com/products/doors-by-type/entry-exterior-doors/|front doors]] [[http://www.ecopowerheating.co.uk|Electric Heating]] [[http://www.directlocks.co.uk|Door Locks]] [[http://www.solidlineproducts.com/|ipad bluetooth keyboard]].  The end result is that DARCS behaves the same as GIT does with its recursive three way merge, except that DARCS uses a special form for its 'merger patch' rather than normal conflict markers.  This makes sure that there are no problems with textual merge and conflict markers (such as mis-matched delimiters, etc).
+Where m(b,c) is a "merger" patch for b1 and c1.  The end result is that DARCS behaves the same as GIT does with its recursive three way merge, except that DARCS uses a special form for its 'merger patch' rather than normal conflict markers.  This makes sure that there are no problems with textual merge and conflict markers (such as mis-matched delimiters, etc).
 
 ----
 CategoryMergeExample
-[[http://www.radiofrequencywelding.com/|radio frequency welding]]
-[[http://www.cashadvance-loans.net/|cash advance loans]]
-[[http://www.sweetrexies.com|candy gift baskets]]
-[[http://www.maps-live.com|live maps]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]
-[[http://cottovsmargarito2live.blogspot.com/|Cotto vs Margarito]]
-[[http://www.linkmysite.net/|Business web directory]]
-[[http://pacquiaoversusmarquez-3.blogspot.com/|Pacquiao vs Marquez]]
-[[http://www.quotessea.com/category/children-quotes/|Children Quotes]]
-[[http://www.kgb-militaryschool.com/view/video/|russian martial arts]]
-[[http://www.geekynchic.com/item_2/Mens-Lego-Brick-Cufflinks-ALL-COLORS.php|lego cufflinks]]
-[[http://www.shopeastwest.com/med/health-wellness/Celebrex/22.html|Celebrex]]
-[[http://www.buygenericlamisil.net/|Lamisil]]
-[[http://www.genericlanoxin.com/|Lanoxin]]

--- a/output-raw/DarcsMerge
+++ b/output-raw/DarcsMerge
@@ -38,11 +38,3 @@ Any merge algorithm that deals directly with patches.
 ----
 
 CategoryMergeAlgorithm
-
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/pacquiao-vs-marquez-official-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://pacquiaovsmarquez3live.com/2011/08/bernard-hopkins-vs-chad-dawson-official-tickets-for-sale/|Hopkins vs Dawson Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/nonito-donaire-vs-omar-narvaez-official-tickets-for-sale/|Donaire vs Narvaez Tickets]]
-[[http://pacquiaovsmarquez3live.com/|Pacquiao vs Marquez]]
-[[http://donairevsnarvaezlive.blogspot.com/|Donaire vs Narvaez]]

--- a/output-raw/FrontPage
+++ b/output-raw/FrontPage
@@ -28,10 +28,7 @@ Note that you must be logged in to edit pages.
  * [[http://www.zooko.com/revision_control_quick_ref.html|Zooko's quick reference]]
  * [[http://better-scm.berlios.de/|the "Better SCM Initiative": another overview of systems]]
  * [[http://planet.revisioncontrol.net|RCS Planet - Blog Collection of RCS developers]]
- * [[http://megaupl0ad.com/скачать-фотошоп-бесплатно-на-русском/|скачать бесплатно фотошоп]] - Download photoshop.
  * [[http://wiki.darcs.net/Theory/Bibliography|Revision Control Bibliography]] more academically leaning publications on revision control
- * [[http://www.hibiscusteasite.com|Hibiscus Tea]] - Domain with Revctrl
- * [[http://www.cashadvance-loans.net/|Cash advance loans]] - Cash advance online
  * RecentChanges: see where people are currently working
  * WikiSandBox: feel free to change this page and experiment with editing
  * FindPage: search or browse the database in various ways
@@ -46,7 +43,7 @@ Is it possible to make a NeutralInterface ?
 
  * [[http://lists.madduck.net/mailman/listinfo/vcs-home|a mailing list]] and [[http://www.theficks.name/VCS-Home/HomePage|a wiki]] for storing $HOME in VCS.
  * [[http://lists.madduck.net/mailman/listinfo/vcs-pkg|a mailing list]] about maintaining distro packages in VCS.
- * [[http://swik.net/|SWiK: the Open Software wiki]] has a brief overview of [[http://swik.net/SCM|SCM]] in general, [[http://swik.net/mercurial|Mercurial]], [[http://swik.net/Subversion|Subversion (SVN)]], [[http://swik.net/tortoiseSVN|the TortoiseSVN Windows Shell Extension]],[[http://www.retoent.com|Refrigeration tools]],[[http://www.nbspark.com|Condensing Units]],[[http://www.kxb2b.com|B2B]],[[http://www.wlxiaoshuo.com|XiaoShuo]],[[http://swik.net/javasvn|JavaSVN]], etc. 
+ * [[http://swik.net/|SWiK: the Open Software wiki]] has a brief overview of [[http://swik.net/SCM|SCM]] in general, [[http://swik.net/mercurial|Mercurial]], [[http://swik.net/Subversion|Subversion (SVN)]], [[http://swik.net/tortoiseSVN|the TortoiseSVN Windows Shell Extension]],[[http://swik.net/javasvn|JavaSVN]], etc. 
 
 == How to use this site ==
 
@@ -61,125 +58,3 @@ A Wiki is a collaborative site, anyone can contribute and share:
 To learn more about what a WikiWikiWeb is, read about MoinMoin:WhyWikiWorks and the MoinMoin:WikiNature. Also, consult the MoinMoin:WikiWikiWebFaq.
 
 This wiki is powered by MoinMoin.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-=== Sponsor Sites ===
-
- *  [[http://carinsurancecompanieshelp.com|car insurance companies]] (Wiki)
- *  [[http://tinyurl.com/7ok6td3|car insurance comparison]] (Wiki)
- *  [[http://carinsurancecomparisonshelp.com|car insurance comparisons]] (Wiki)
- *  [[http://vehicleinsurancefinder.com|vehicle insurance]] (Wiki)
- *  [[http://tinyurl.com/cxoz8tb|compro oro]] (Wiki)
- *  [[http://www.cartomanziaetarocchigratis.com/|cartomanzia]] (Wiki)
- *  [[http://lahorehairtransplant.com|Hair transplant in Lahore]] (Wiki)
- * [[http://www.pk-forum.ch|Pensionskasse]] (Wiki)

--- a/output-raw/Glossary
+++ b/output-raw/Glossary
@@ -6,7 +6,7 @@
 }}} See AccidentalCleanMerge.
 
  <<Anchor(aliasing)>>
- aliasing:: aliasing is taking two logically distinct entities and causing them to be treated as equivalent, at least in certain contexts.  Aliasing is similar to suturing, but the assertion is weaker ({{{x == y}}}, not {{{x is y}}}), and is trivial to undo. [[http://www.solidlineproducts.com/|best cases for ipad]]
+ aliasing:: aliasing is taking two logically distinct entities and causing them to be treated as equivalent, at least in certain contexts.  Aliasing is similar to suturing, but the assertion is weaker ({{{x == y}}}, not {{{x is y}}}), and is trivial to undo.
 
  <<Anchor(ambiguouscleanmerge)>>
  ambiguous clean merge:: See AmbiguousCleanMerge.
@@ -15,9 +15,7 @@
  branch:: A named line of development.  May be viewed either as a sequence of [[#changeset|changesets]] or as a sequence of [[#snapshot|snapshots]] (but see the warning about the non-duality of these representations under [[#snapshot|snapshot]]).  In the context of a [[#repository|repository]], a branch may be viewed as a subgraph of the repository [[#DAG|DAG]] with two distinguished vertices; the branch point where it diverges from other lines of development, and a [[#tip|tip]]. Often branches are tied to a [[#repository|repository]] in a many-to-one relationship. But other implementations are possible, for instance, [[Monotone]] supports fully distributed branches which do not exist exclusively on top of any particular [[#repository|repository]], while other systems such as [[Darcs]] and [[Bzr]] tie branches to repositories in a one-to-one fashion.
 
  <<Anchor(changeset)>>
- changeset:: A collection of [[#delta|deltas]] to a set of files, considered as a unit and (in modern VCSes) with metadata including a change comment and a timestamp attached.  To fully capture the history of a line of development, changesets must also record file additions (which may be modeled as a delta from an empty file), file deletions, and file renames.  See also [[#weave|weave]] and [[#snapshot|snapshot]]. [[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]] [[http://www.sweetrexies.com/|gift baskets]] [[http://www.aeg.cc|fiber to the home construction firms]]
-[[http://www.onlyexclusivetravel.com/2428/1124/objects/resorts/soneva-kiri-by-six-senses.html|Soneva Kiri]]
-
+ changeset:: A collection of [[#delta|deltas]] to a set of files, considered as a unit and (in modern VCSes) with metadata including a change comment and a timestamp attached.  To fully capture the history of a line of development, changesets must also record file additions (which may be modeled as a delta from an empty file), file deletions, and file renames.  See also [[#weave|weave]] and [[#snapshot|snapshot]].
 
  <<Anchor(checkin)>>
  checkin:: Synonym for [[#commit|commit]] used in older VCSes (SCCS, RCS, CVS). This is why "ci" sometime appears as an alias for the commit operation in the command-line interfaces of VCSes that emulate CVS/Subversions's UI.
@@ -44,7 +42,7 @@
  convergent scalar merge:: A scalar merge algorithm related to PreciseCodevilleMerge. See ConvergentScalarMerge.
 
  <<Anchor(DAG)>>
- Directed Acyclic Graph (DAG):: A diagram (graph) made up of points connected by arrows (directed), where no arrow can lead back to an earlier point; in other words, the arrows cannot form a loop (acyclic).  [[#revision|Revisions]] in a VCS may be viewed as nodes in a DAG and the [[#changeset|changesets]] connecting them as links expressing the "parent-of" relationship. [[#tip|Tip]] revisions will have valence 1, most ordinary revisions will have valence 2, and revisions representing a branch point [[http://www.contentrules.com/|global content]] or merge will have valence 3. [[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
+ Directed Acyclic Graph (DAG):: A diagram (graph) made up of points connected by arrows (directed), where no arrow can lead back to an earlier point; in other words, the arrows cannot form a loop (acyclic).  [[#revision|Revisions]] in a VCS may be viewed as nodes in a DAG and the [[#changeset|changesets]] connecting them as links expressing the "parent-of" relationship. [[#tip|Tip]] revisions will have valence 1, most ordinary revisions will have valence 2, and revisions representing a branch point or merge will have valence 3.
 
  <<Anchor(delta)>>
  delta:: A description of changes between two versions of a file, usually as a sequence of line-oriented additions and deletions and replacements.  Such line-oriented deltas are often represented in a standard notation derived from the output format of the Unix '''diff(1)''' command.  There is a well-defined concept of deltas between binary files as well, but no standard notation for expressiong them.
@@ -56,10 +54,7 @@
  implicit undo:: See ImplicitUndo.
 
  <<Anchor(locking)>>
- locking:: Early VCSes (SCCS, RCS) avoided the merging problem by awarding developers temporary but exclusive write locks on files. This approach did not scale well and was abandoned in second- and third-generation VCSes. [[http://mayweatherversusortiz.com/2011/09/pacquiao-vs-marquez-official-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://pacquiaovsmarquez3live.com/2011/08/bernard-hopkins-vs-chad-dawson-official-tickets-for-sale/|Hopkins vs Dawson Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/nonito-donaire-vs-omar-narvaez-official-tickets-for-sale/|Donaire vs Narvaez Tickets]]
-
+ locking:: Early VCSes (SCCS, RCS) avoided the merging problem by awarding developers temporary but exclusive write locks on files. This approach did not scale well and was abandoned in second- and third-generation VCSes.
 
 
  <<Anchor(markmerge)>>
@@ -93,7 +88,7 @@
  second-generation:: See [[#vcsgenerations|generations]].
 
  <<Anchor(snapshot)>>
- snapshot:: A collection of files and directories considered as a timestamped unit, possibly with metadata such as a revision comment attached.  The revision history of a project may be considered either as a sequence of snapshots or as a sequence of the [[#changeset|changesets]] connecting them.  However, these representations are not perfectly dual [[http://www.casinobonuscity.net/|no deposit casino bonus codes 2012]].  Notably, moving from a changeset-sequence representation to a snapshot-sequence representation loses information about file and directory add, delete, and rename operations. While additions and deletions can be reliably inferred by comparing snapshots, renames cannot be; this has some subtle and occasionally nasty ripple effects. [[http://pacquiaovsmarquez3live.com/|Pacquiao vs Marquez]]
+ snapshot:: A collection of files and directories considered as a timestamped unit, possibly with metadata such as a revision comment attached.  The revision history of a project may be considered either as a sequence of snapshots or as a sequence of the [[#changeset|changesets]] connecting them.  However, these representations are not perfectly dual.  Notably, moving from a changeset-sequence representation to a snapshot-sequence representation loses information about file and directory add, delete, and rename operations. While additions and deletions can be reliably inferred by comparing snapshots, renames cannot be; this has some subtle and occasionally nasty ripple effects.
 
  <<Anchor(staircasemerge)>>
  staircase merge:: A simple merge example: {{{
@@ -123,26 +118,10 @@
  VCS:: Version-Control System. The most common of a handful of competing acronyms for the software this site is about.  Others include SCM for Source Code Manager and (rarely) SCCS for Source Code Control System.  The latter is also the proper name of the original VCS.
 
  <<Anchor(vcsgenerations)>>
- VCS generations:: There have, broadly speaking, been three generations of VCSes.  The first was exemplified by SCCS and RCS -- centralized and [[#locking|locking]], without support for development distributed across a network.  The second generation was exemplified by CVS and Subversion, which introduced merging and added support for distributed development but retained the centralized model based on one master repository per project.  Third-generation VCSes support a fully decentralized model; master repositories may exist as a matter of per-project policy, but the tools are all designed to support history merges between peer repositories. [[http://donairevsnarvaezlive.blogspot.com/|Donaire vs Narvaez]]
+ VCS generations:: There have, broadly speaking, been three generations of VCSes.  The first was exemplified by SCCS and RCS -- centralized and [[#locking|locking]], without support for development distributed across a network.  The second generation was exemplified by CVS and Subversion, which introduced merging and added support for distributed development but retained the centralized model based on one master repository per project.  Third-generation VCSes support a fully decentralized model; master repositories may exist as a matter of per-project policy, but the tools are all designed to support history merges between peer repositories.
 
  <<Anchor(weave)>>
  weave:: A data structure representing a full ordering of lines for a particular file along with information about which lines exist for each historical revision. [[SCCS]] is the classic example. A number of merge algorithms are based on weaves. See [[Weave]], WeaveMerge.  One of the fundamental design desisions in a VCS is whether change history will be represented as a weave or a sequence of [[#delta|deltas]].
 
  <<Anchor(workspace)>>
  workspace:: An editable copy of the state of a repository at a particular revision (or merge of several revisions) where a user can resolve conflicts and make new changes, then record them as a new revision. Also "working copy".
-[[http://www.pressurewashingmariettaga.net|pressure washing marietta ga]]
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]
-[[http://encoredj.org|grand rapids djs]]
-
-Thanks to Angel - [[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-trilogy-free-live-streaming/|Pacquiao vs Marquez Live Streaming]]
-[[http://cottovsmargarito2.com/|Cotto vs Margarito]]
-[[http://www.oilfieldwiki.com/wiki/Asphaltenes|asphaltene]]
-[[http://pacquiaovsmarquez3live.com/2011/08/andre-ward-vs-carl-froch-official-tickets-for-sale/|Ward vs Froch Tickets]]
-[[http://cottovsmargarito2live.blogspot.com/|Cotto vs Margarito]]
-[[http://pacquiaoversusmarquez-lll.blogspot.com/|Pacquiao vs Marquez]]
-[[http://pacquiaoversusmarquez-3.blogspot.com/|Pacquiao vs Marquez]]

--- a/output-raw/KenSchalk
+++ b/output-raw/KenSchalk
@@ -6,8 +6,6 @@
 Email: [[MailTo(ken AT xorian DOT net)]]
 
 Works on: [http://www.vestasys.org/ Vesta]
- 
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]]  [[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
 
 IRC nick: xorian
 
@@ -15,12 +13,3 @@ I also go by "xorian" [https://sourceforge.net/users/xorian/ on SourceForge] and
 
 ----
 CategoryHomepage
-
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-trilogy-free-live-streaming/|Pacquiao vs Marquez Live Streaming]]
-[[http://cottovsmargarito2.com/|Cotto vs Margarito]]
-[[http://pacquiaovsmarquez3live.com/2011/08/andre-ward-vs-carl-froch-official-tickets-for-sale/|Ward vs Froch Tickets]]
-[[http://cottovsmargarito2live.blogspot.com/|Cotto vs Margarito]]
-[[http://pacquiaoversusmarquez-lll.blogspot.com/|Pacquiao vs Marquez]]
-[[http://pacquiaoversusmarquez-3.blogspot.com/|Pacquiao vs Marquez]]
-[[http://pacquiaovsmarquez3livestreaming.com/2011/09/pacquiao-vs-marquez-live-streaming/|Pacquiao vs Marquez Live Streaming]]
-[[http://best-weightlossdiets.com/|Best Weight Loss Diet]]

--- a/output-raw/MarkMerge
+++ b/output-raw/MarkMerge
@@ -29,18 +29,8 @@ The most interesting things about *-merge are:
 
 = Related =
 
-Code Algorithm for [[http://www.alignmix.com|Sales Territory Mapping]] Software by AlignMix.
-
 CodevilleMerge
 
 ----
 
 CategoryMergeAlgorithm CategoryScalarMerge
-
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/pacquiao-vs-marquez-official-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://pacquiaovsmarquez3live.com/2011/08/bernard-hopkins-vs-chad-dawson-official-tickets-for-sale/|Hopkins vs Dawson Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/nonito-donaire-vs-omar-narvaez-official-tickets-for-sale/|Donaire vs Narvaez Tickets]]
-[[http://pacquiaovsmarquez3live.com/|Pacquiao vs Marquez]]
-[[http://donairevsnarvaezlive.blogspot.com/|Donaire vs Narvaez]]

--- a/output-raw/NathanielSmith
+++ b/output-raw/NathanielSmith
@@ -10,11 +10,3 @@ IRC nick: njs
 
 ----
 CategoryHomepage
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]

--- a/output-raw/NeutralInterface
+++ b/output-raw/NeutralInterface
@@ -113,16 +113,8 @@ In the command line, the '+' marker and the field list afterwards is optional.
 If it is present, the field list after the '+' marker (non-inclusive; '+' and
 no field list means empty field list) is parsed in the same way as the "-s"
 argument, and the same considerations apply - it is recommended to always
-specify the field list. [[http://www.solidlineproducts.com/|best cases for ipad]]
+specify the field list.
 
 === library (future) ===
 
-[[http://www.tec-idiomes.com/|Estudiar ingles en el extranjero]]
 Once some implementations exist, it should be easy to wrap all calls into a library. This library can initially call the stand-alone command, or possibly shell mode if available. Once the interface is well-established, the shim library can be replaced with direct calls to the SCM backend for improved performance.
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]
-[[http://www.clickxposure.com/|chicago seo company]]

--- a/output-raw/PetrBaudis
+++ b/output-raw/PetrBaudis
@@ -11,16 +11,3 @@ IRC nick: pasky
 ----
 
 CategoryHomepage CategoryHomepage
-
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://www.sweetrexies.com/|gift basket ideas]]
-[[http://encoredj.org|grand rapids photo booth]]
-[[http://www.aeg.cc| fiber to the home construction firms]]
-[[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/pacquiao-vs-marquez-official-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://www.oilfieldwiki.com/wiki/Asphaltenes|asphaltene]]
-[[http://pacquiaovsmarquez3live.com/2011/08/bernard-hopkins-vs-chad-dawson-official-tickets-for-sale/|Hopkins vs Dawson Tickets]]
-[[http://mayweatherversusortiz.com/2011/09/nonito-donaire-vs-omar-narvaez-official-tickets-for-sale/|Donaire vs Narvaez Tickets]]
-[[http://pacquiaovsmarquez3live.com/|Pacquiao vs Marquez]][[http://www.contentrules.com/|global content]]
-[[http://donairevsnarvaezlive.blogspot.com/|Donaire vs Narvaez]]
-[[http://www.pressurewashingmariettaga.net|pressure washing marietta ga]]

--- a/output-raw/PreciseCodevilleMerge
+++ b/output-raw/PreciseCodevilleMerge
@@ -33,9 +33,5 @@ An even less featureful merge algorithm than no frills is SimpleWeaveMerge, whic
 This uses the [[http://en.wikipedia.org/wiki/Patience_sorting|Patience sorting]] algorithm  to find the longest common subset.
 
 ----
-= Resources =
-*[[http://www.hasstel.com/|Dobra Strona]] Uwodzenie
-*[[http://jakszybkoschudnacz.wordpress.com/|Kliknij Tutaj]] Odchudzanie
-----
 
 CategoryMergeAlgorithm

--- a/output-raw/RevctrlTalks
+++ b/output-raw/RevctrlTalks
@@ -1,14 +1,14 @@
 Revctrl TV!
 
-== darcs == [[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
+== darcs ==
  * [http://ftp.belnet.be/mirrors/FOSDEM/2006/FOSDEM2006-darcs.avi David Roundy at FOSDEM 2006] (avi)
 
-== git == [[http://pacquiaovsmarquez3live.com/2011/08/andre-ward-vs-carl-froch-official-tickets-for-sale/|Ward vs Froch Tickets]]
+== git ==
 
  * [http://www.youtube.com/watch?v=4XpnKHJAok8 Linus Torvalds Google TechTalk]
  * [http://video.google.com/videoplay?docid=-3999952944619245780 Randal Schwartz Google TechTalk]
 
-== mercurial == [[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
+== mercurial ==
 
  * [http://video.google.com/videoplay?docid=-7724296011317502612 Bryan O'Sullivan Google TechTalk]
 [http://www.crusherone.com]
@@ -16,11 +16,3 @@ Revctrl TV!
 == subversion ==
 
  * [http://ftp.belnet.be/mirrors/FOSDEM/2006/FOSDEM2006-subversion.avi Greg Stein FOSDEM 2006] (avi)
-
-
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]

--- a/output-raw/Rollback
+++ b/output-raw/Rollback
@@ -189,13 +189,3 @@ Everything but DARCS.
 ----
 
 CategoryMergeExample
-
-
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-tickets-for-sale/|Pacquiao vs Marquez Tickets]]
-[[http://cottovsmargarito2.com/2011/09/buy-cotto-vs-margarito-tickets-official-tickets-for-sale-here/|Cotto vs Margarito Tickets]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]

--- a/output-raw/RossCohen
+++ b/output-raw/RossCohen
@@ -10,10 +10,3 @@ IRC nick: rcohen
 
 ----
 CategoryHomepage
-
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]

--- a/output-raw/ThreeWayTextMergeImplementation
+++ b/output-raw/ThreeWayTextMergeImplementation
@@ -43,10 +43,3 @@ The bzr implementation does a three-way comparison like so:
  1. In sections where OTHER and BASE coincide, pick THIS
  1. Sections in which both OTHER and THIS differ from BASE are treated as conflicts
  1. (Optional) a two-way merge is performed in conflict regions, to reduce conflicts.  (This step is optional, because it loses the connection between BASE and conflict regions)
-
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]

--- a/output-raw/Weave
+++ b/output-raw/Weave
@@ -12,10 +12,3 @@ A weave can be used for ["Resolution"] by taking all ancestors of the current no
 To merge using a weave, go through the weave a line at a time, throwing out lines which are dead on both ancestors and pulling in lines which are alive in both ancestors. Sections between lines which are alive in both ancestors are potential conflict sections. For a potential conflict section, check which side would win in a conflict for each line individually (that is, merge together the fact of that line's being present or not). If the same side would win all of those, then that side wins the conflict, otherwise the conflict has to be escalated to the user.
 
 Some merge GUIs present common ancestors in conflict sections. In a distributed system there may be no single common ancestor of a particular section, but a reasonable facsimile of one can be produced by determining whether each individual line would be present in a 'common ancestor', then put together all the ones which would. The method of determining common ancestors is completely dependant on the particulars of line versioning in a given weave implementation.
-
-[[http://pacquiaovsmarquez3live.com/2011/07/pacquiao-vs-marquez-trilogy-free-live-streaming/|Pacquiao vs Marquez Live Streaming]]
-[[http://cottovsmargarito2.com/|Cotto vs Margarito]]
-[[http://pacquiaovsmarquez3live.com/2011/08/andre-ward-vs-carl-froch-official-tickets-for-sale/|Ward vs Froch Tickets]]
-[[http://cottovsmargarito2live.blogspot.com/|Cotto vs Margarito]]
-[[http://pacquiaoversusmarquez-lll.blogspot.com/|Pacquiao vs Marquez]]
-[[http://pacquiaoversusmarquez-3.blogspot.com/|Pacquiao vs Marquez]]

--- a/output-raw/WikiNode
+++ b/output-raw/WikiNode
@@ -10,20 +10,16 @@ Welcome to the Revctrl wiki, where we discuss various revision control systems, 
   * NeutralInterface
 
 == neighboring wiki with wikinodes ==
-  * [[http://www.imcredo.com/|PPC Agency]]
-  * [[http://www.solidlineproducts.com/|cases ipad 2]]
-  * [[http://www.casinoluckywin.com/|Best Online Casino]]
   * [http://communitywiki.org/odd/SoftwareBazaar/WikiNode the Software Bazaar wiki] mentions [http://communitywiki.org/odd/SoftwareBazaar/distributed_wiki the distributed wiki] which has some similarities to a distributed version control system.
   * [http://alliance.seas.upenn.edu/~bcpierce/wiki/index.php?n=Main.WikiNode the Unison wiki] discusses Unison, a tool for rapidly synchronizing 2 directories over a slow network connection. It can be used as a crude revision control system (backups), or it can be used in conjunction with a standard revision control system to speed up check-ins and check-outs over a slow connection.
   * [http://wiki.linuxquestions.org/wiki/WikiNode the Linux Questions wiki] briefly [http://wiki.linuxquestions.org/wiki/Revision_control mentions revision control]
-  * [http://wiki.synchroedit.com/index.php/WikiNode the SynchroEdit wiki] discusses Synchro Edit, an editor that allows multiple users to share a single X(HT)ML or text document, edit the document the same time, and synchronize changes so that all users and [[http://www.womencasinos.co.uk/|Casino Ladies]] have the same version.
+  * [http://wiki.synchroedit.com/index.php/WikiNode the SynchroEdit wiki] discusses Synchro Edit, an editor that allows multiple users to share a single X(HT)ML or text document, edit the document the same time, and synchronize changes so that all users have the same version.
 
 
 == neighboring wiki that, alas, still lack wikinodes ==
 
   * [http://wiki.darcs.net/ the darcs wiki] discusses the "darcs" version control system. ''needs wikinode''
   * [http://wikiindex.org/Arch_Wiki the Arch wiki] discusses the Arch Revision Control Systems such as GNU Arch and Bazaar and ArX. Arch is a distributed revision control system. ''needs wikinode''
-  * [[http://megaupl0ad.com/скачать-фотошоп-бесплатно-на-русском/ | фотошоп скачать]]
   * [http://venge.net/mtn-wiki/ the monotone wiki]
   * [http://git.or.cz/gitwiki/ the git wiki]
   * [http://selenic.com/mercurial/wiki/ the mercurial wiki] discusses the mercurial version control system. ''needs wikinode''
@@ -33,11 +29,3 @@ Welcome to the Revctrl wiki, where we discuss various revision control systems, 
 
 Please add closely-related wiki to this page (preferably linking directly to their wikinodes).
 Prune less-related wiki, moving information about them to the [http://wikiindex.org/ WikiIndex].
-[[http://www.casinomagic.co.uk/mobile-casino/ |mobile casino]]
-[[http://pacquiaovsmarquez3live.com/|Hopkins vs Dawson]]
-[[http://mayweatherversusortiz.com/|Hopkins vs Dawson]]
-[[http://pacquiaovsmarquez3live.com/|Donaire vs Narvaez]]
-[[http://mayweatherversusortiz.com/|Donaire vs Narvaez]]
-[[http://pacquiaovsmarquez3live.com/2011/10/watch-hopkins-vs-dawson-live-streaming-online/|Hopkins vs Dawson Live Streaming]]
-[[http://mayweatherversusortiz.com/2011/10/watch-donaire-vs-narvaez-live-streaming-online/|Donaire vs Narvaez Live Streaming]]
-[[http://www.sweetrexies.com/|gift basket ideas]]


### PR DESCRIPTION
The revctrl.org website was a great resource, and I was glad to discover that you preserved it.

This is an attempt to remove the spam links from the files in `output-raw`. I didn't do the same to `output-html` because (a) I expect that the information there is all redundant with `output-raw`, and (b) it's full of broken links and missing CSS, so probably not of much use (correct me if you think I'm wrong). In fact, I'll probably submit a separate PR to delete it and `attachments.tar.gz`.

I also touched up the `README.md` file (in a separate commit) in a way that I hope retains the flavor of the original while trying not to put words in your mouth. Feel free to tweak it.
